### PR TITLE
 Change OS from Ubuntu 18.04 to 22.04 on Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:22.04
 RUN apt-get update && apt-get install -y git make build-essential liblzma-dev libbz2-dev zlib1g-dev libncurses5-dev libncursesw5-dev
 
 RUN cd /tmp \
-  && git clone https://github.com/xjtu-omics/msisensor-pro.git \
+  && git clone https://github.com/saphetor/msisensor-pro.git \
   && cd msisensor-pro \
   && ./INSTALL \
   && cp -r /tmp/msisensor-pro/binary/msisensor-pro /usr/bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:22.04
 
 RUN apt-get update && apt-get install -y git make build-essential liblzma-dev libbz2-dev zlib1g-dev libncurses5-dev libncursesw5-dev
 


### PR DESCRIPTION
## Description

Fix [IN-669](https://saphetor.atlassian.net/browse/IN-669)
Update base image from Ubuntu 18 to Ubuntu 22 .

## Changes

Changed base image to Ubuntu 22.04. Tested locally. No errors during the build.

![Screenshot from 2024-02-20 11-08-18](https://github.com/saphetor/msisensor-pro/assets/121862515/1856cec0-e151-4c06-b95c-7b8af2dea030)



[IN-669]: https://saphetor.atlassian.net/browse/IN-669?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ